### PR TITLE
Improve exception message for failed optimizations

### DIFF
--- a/Classes/Service/OptimizerService.php
+++ b/Classes/Service/OptimizerService.php
@@ -71,7 +71,7 @@ class OptimizerService
 
         if (!file_exists($optimizedTemporaryPathAndFilename)) {
             Files::unlink($originalTemporaryPathAndFilename);
-            throw new \RuntimeException('Optimization not successful with exit status ' . $result . ' and the following output: ' . implode(chr(10), $output));
+            throw new \RuntimeException(sprintf("Optimization not successful for command: %s\nExit status code: %s\nOutput:\n%s", $commandString, $result, implode(chr(10), $output)), 1601633863);
         }
 
         $bestResultPathAndFilename = (filesize($originalTemporaryPathAndFilename) <= filesize($optimizedTemporaryPathAndFilename)) ? $originalTemporaryPathAndFilename : $optimizedTemporaryPathAndFilename;


### PR DESCRIPTION
Changes the exception message from
```
Optimization not successful with exit status <code> and the following output: <output>
```
to
```
Optimization not successful for command: <the command string>
Exit status code: <code>
Output:
<output>
```

and adds a unique exception number