### PR TITLE
Add Compatibility for Neos and Flow 7.0

### DIFF
--- a/Classes/ImageOptimizerTarget.php
+++ b/Classes/ImageOptimizerTarget.php
@@ -133,8 +133,12 @@ class ImageOptimizerTarget implements TargetInterface
         /** @var StorageObject $resource */
         foreach ($collection->getObjects($callback) as $resource) {
             if ($this->needsToBeOptimized($resource)) {
-                $optimizedResource = $this->optimizerService->optimize($resource->getStream(), $resource->getFilename(), $this->options['optimizedCollection'], $this->getOptimizerConfigurationForMediaType($resource->getMediaType()));
-                $this->prepareForPersistence($optimizedResource, $resource->getSha1(), $resource->getFilename());
+                try {
+                    $optimizedResource = $this->optimizerService->optimize($resource->getStream(), $resource->getFilename(), $this->options['optimizedCollection'], $this->getOptimizerConfigurationForMediaType($resource->getMediaType()));
+                    $this->prepareForPersistence($optimizedResource, $resource->getSha1(), $resource->getFilename());
+                } catch (\Exception $exception) {
+                    // Ignore the error and use the original resource
+                }
             }
         }
         $this->realTarget->publishCollection($collection, $callback);
@@ -153,8 +157,12 @@ class ImageOptimizerTarget implements TargetInterface
     public function publishResource(PersistentResource $resource, CollectionInterface $collection)
     {
         if ($this->needsToBeOptimized($resource)) {
-            $optimizedResource = $this->optimizerService->optimize($resource->getStream(), $resource->getFilename(), $this->options['optimizedCollection'], $this->getOptimizerConfigurationForMediaType($resource->getMediaType()));
-            $this->prepareForPersistence($optimizedResource, $resource->getSha1(), $resource->getFilename());
+            try {
+                $optimizedResource = $this->optimizerService->optimize($resource->getStream(), $resource->getFilename(), $this->options['optimizedCollection'], $this->getOptimizerConfigurationForMediaType($resource->getMediaType()));
+                $this->prepareForPersistence($optimizedResource, $resource->getSha1(), $resource->getFilename());
+            } catch (\Exception $exception) {
+                // Ignore the error and use the original resource
+            }
         }
         $this->realTarget->publishResource($resource, $collection);
     }

--- a/Migrations/Mysql/Version20180731154744.php
+++ b/Migrations/Mysql/Version20180731154744.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 
 namespace Neos\Flow\Persistence\Doctrine\Migrations;
 
-use Doctrine\DBAL\DBALException;
-use Doctrine\DBAL\Migrations\AbortMigrationException;
-use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\Migrations\Exception\AbortMigration;
+use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Exception;
 
 /**
  * Add relation table for optimized resources.
@@ -17,7 +17,7 @@ class Version20180731154744 extends AbstractMigration
     /**
      * @return string
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Add relation table for optimized resources.';
     }
@@ -25,10 +25,10 @@ class Version20180731154744 extends AbstractMigration
     /**
      * @param Schema $schema
      * @return void
-     * @throws DBALException
-     * @throws AbortMigrationException
+     * @throws Exception
+     * @throws AbortMigration
      */
-    public function up(Schema $schema)
+    public function up(Schema $schema): void
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on "mysql".');
 
@@ -39,10 +39,10 @@ class Version20180731154744 extends AbstractMigration
     /**
      * @param Schema $schema
      * @return void
-     * @throws DBALException
-     * @throws AbortMigrationException
+     * @throws Exception
+     * @throws AbortMigration
      */
-    public function down(Schema $schema)
+    public function down(Schema $schema): void
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on "mysql".');
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "email": "support@flownative.com"
     },
     "require": {
-        "neos/flow": "^4.0 || ^5.0 || ^6.0 || dev-master"
+        "neos/flow": "^4.0 || ^5.0 || ^6.0 || ^7.0 || dev-master"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The following changes had to be made:

1. Doctrine Abstract Migration moved in namespace to Doctrine\Migrations
2. Doctrine AbortMigrationException moved in namespace to Doctrine\Migrations\Exception and removed to AbortMigration
3. Return types are required to be compatible with AbstractMigration

Deprecation Updates:
1. DBALException has been removed in favour of Exception